### PR TITLE
cleaned up source_id template

### DIFF
--- a/CORDEX_source_id.json
+++ b/CORDEX_source_id.json
@@ -14,36 +14,31 @@
             "license":"REMO2020 data produced by GERICS is licensed under a Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0/). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing input4MIPs output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file). The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.",
             "model_component":{
                 "aerosol":{
-                    "description":"none",
-                    "native_nominal_resolution":"250 km"
+                    "description":"MACv2"
                 },
                 "atmos":{
-                    "description":"dynamic",
-                    "native_nominal_resolution":"250 km"
+                    "description":"dynamic"
                 },
                 "atmosChem":{
-                    "description":"none",
-                    "native_nominal_resolution":"none"
+                    "description":"none"
                 },
                 "land":{
-                    "description":"none",
-                    "native_nominal_resolution":"none"
+                    "description":"none"
                 },
                 "landIce":{
-                    "description":"none",
-                    "native_nominal_resolution":"none"
+                    "description":"none"
                 },
                 "ocean":{
-                    "description":"prescribed",
-                    "native_nominal_resolution":"none"
+                    "description":"prescribed"
+                },
+                "lake":{
+                    "description":"FLake"
                 },
                 "ocnBgchem":{
-                    "description":"none",
-                    "native_nominal_resolution":"none"
+                    "description":"none"
                 },
                 "seaIce":{
-                    "description":"none",
-                    "native_nominal_resolution":"none"
+                    "description":"none"
                 }
             },
             "release_year":"2022",


### PR DESCRIPTION
removed native_nominal_resolution info, added some more info for remo example, see #28 