### PR TITLE
pin `cmor>=3.8.0`

### DIFF
--- a/.github/workflows/cfchecks.yaml
+++ b/.github/workflows/cfchecks.yaml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # python versions
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cfchecks.yaml
+++ b/.github/workflows/cfchecks.yaml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # python versions
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - pytest
   - py-cordex
   - cf_xarray
-  - cmor>=3.7.0
+  - cmor>=3.8.0
   - fsspec
   - requests
   - aiohttp


### PR DESCRIPTION
* required due to https://github.com/PCMDI/cmor/pull/727
* drop `python3.8` tests