### PR TITLE
Rename 'olevel' to 'depth_coord' in coordinates table

### DIFF
--- a/Tables/CORDEX-CMIP6_coordinate.json
+++ b/Tables/CORDEX-CMIP6_coordinate.json
@@ -230,7 +230,7 @@
             "bounds_values": "",
             "generic_level_name": ""
         },
-        "olevel": {
+        "depth_coord": {
             "standard_name": "depth",
             "units": "m",
             "axis": "Z",


### PR DESCRIPTION
fixes #162 